### PR TITLE
DEP-211: pg_dump without schema name in data file

### DIFF
--- a/src/bin/pg_dump/pg_backup.h
+++ b/src/bin/pg_dump/pg_backup.h
@@ -160,6 +160,9 @@ typedef struct _dumpOptions
 	bool		outputBlobs;
 	int			outputNoOwner;
 	char	   *outputSuperuser;
+
+	const char		*active_schema;
+	const char		*output_schema;
 } DumpOptions;
 
 /*

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -9156,7 +9156,7 @@ dumpComment(Archive *fout, const char *type, const char *name,
 	}
 
 	/* If a comment exists, build COMMENT ON statement */
-	if (ncomments < 0)
+	if (ncomments > 0)
 	{
 		if (strcmp(type, "SCHEMA") != 0)
 		{

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -9158,35 +9158,37 @@ dumpComment(Archive *fout, const char *type, const char *name,
 	/* If a comment exists, build COMMENT ON statement */
 	if (ncomments > 0)
 	{
-		if (strcmp(type, "SCHEMA") != 0)
+		if (strcmp(type, "SCHEMA") == 0)
 		{
-			PQExpBuffer query = createPQExpBuffer();
-			PQExpBuffer tag = createPQExpBuffer();
-
-			appendPQExpBuffer(query, "COMMENT ON %s ", type);
-			if (namespace && *namespace)
-				appendPQExpBuffer(query, "%s.", fmtId(namespace));
-			appendPQExpBuffer(query, "%s IS ", name);
-			appendStringLiteralAH(query, comments->descr, fout);
-			appendPQExpBufferStr(query, ";\n");
-
-			appendPQExpBuffer(tag, "%s %s", type, name);
-
-			/*
-			* We mark comments as SECTION_NONE because they really belong in the
-			* same section as their parent, whether that is pre-data or
-			* post-data.
-			*/
-			ArchiveEntry(fout, nilCatalogId, createDumpId(),
-						tag->data, namespace, NULL, owner,
-						false, "COMMENT", SECTION_NONE,
-						query->data, "", NULL,
-						&(dumpId), 1,
-						NULL, NULL);
-
-			destroyPQExpBuffer(query);
-			destroyPQExpBuffer(tag);
+		    return;
 		}
+
+		PQExpBuffer query = createPQExpBuffer();
+		PQExpBuffer tag = createPQExpBuffer();
+
+		appendPQExpBuffer(query, "COMMENT ON %s ", type);
+		if (namespace && *namespace)
+			appendPQExpBuffer(query, "%s.", fmtId(namespace));
+		appendPQExpBuffer(query, "%s IS ", name);
+		appendStringLiteralAH(query, comments->descr, fout);
+		appendPQExpBufferStr(query, ";\n");
+
+		appendPQExpBuffer(tag, "%s %s", type, name);
+
+		/*
+		 * We mark comments as SECTION_NONE because they really belong in the
+		 * same section as their parent, whether that is pre-data or
+		 * post-data.
+		 */
+		ArchiveEntry(fout, nilCatalogId, createDumpId(),
+					 tag->data, namespace, NULL, owner,
+					 false, "COMMENT", SECTION_NONE,
+					 query->data, "", NULL,
+					 &(dumpId), 1,
+					 NULL, NULL);
+
+		destroyPQExpBuffer(query);
+		destroyPQExpBuffer(tag);
 	}
 }
 

--- a/src/fe_utils/string_utils.c
+++ b/src/fe_utils/string_utils.c
@@ -155,7 +155,7 @@ fmtQualifiedId(int remoteVersion, const char *schema, const char *id)
 	/* Suppress schema name if fetching from pre-7.3 DB */
 	if (remoteVersion >= 70300 && schema && *schema)
 	{
-		appendPQExpBuffer(lcl_pqexp, "%s.", fmtId(schema));
+		appendPQExpBuffer(lcl_pqexp, "");
 	}
 	appendPQExpBufferStr(lcl_pqexp, fmtId(id));
 


### PR DESCRIPTION
Changes for dumping a `single` whole schema. Not tested against multiple schemas in one dump.
- Do not dump schema name to file.
- Set schema name will be restored to file: new required argument added: `-z` or `--output_schema`.
- Do not dump index, trigger. 
- Disable comments for schema.
------
Sample Usage:

pg_dump -h localhost -p 5438 -U datalake_rs_prod_readonly responsible_sourcing_prod -v `-f rise.sql` --no-acl --no-owner `-n public` --quote-all-identifiers `--output-schema rise_raw`